### PR TITLE
Handle missing image files gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Here’s a summary of recent updates and changes.
     - Matching method: LightGlue, More efficient LoFTR
 - **New Feature:** Introduced WildFusion (https://arxiv.org/abs/2408.12934), calibrated score fusion for high-accuracy animal reidentification. Added calibration methods.
 - **Bug Fixes:** Resolved issues with knn and ranking inference methods and many more.
+- **Improved Robustness:** `ImageDataset` now checks for missing or corrupt files and raises informative errors.
 
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,7 @@ Here’s a summary of recent updates and changes.
     - Matching method: LightGlue, More efficient LoFTR
 - **New Feature:** Introduced WildFusion, calibrated score fusion for high-accuracy animal reidentification. Added calibration methods.
 - **Bug Fixes:** Resolved issues with knn and ranking inference methods and many more.
+- **Improved Robustness:** `ImageDataset` now checks for missing or corrupt files and raises informative errors.
 
 
 ## Installation

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,7 +1,8 @@
 
 import os
 import pytest
-from wildlife_tools.data import WildlifeDataset, FeatureDataset
+import pandas as pd
+from wildlife_tools.data import WildlifeDataset, FeatureDataset, ImageDataset
 from PIL.Image import Image
 
 load_options = ['full', 'full_mask', 'full_hide', 'bbox', 'bbox_mask', 'bbox_hide', 'crop_black']
@@ -38,3 +39,19 @@ def test_sift_feature_dataset_save_load(dataset, features_sift):
     assert a.metadata.equals(b.metadata)
     assert len(a.features) == len(b.features)
     os.remove('test.pkl')
+
+
+def test_image_dataset_missing_file(tmp_path):
+    df = pd.DataFrame({'path': ['missing.jpg'], 'identity': ['a']})
+    dataset = ImageDataset(df, root=tmp_path)
+    with pytest.raises(FileNotFoundError):
+        dataset[0]
+
+
+def test_image_dataset_corrupt_file(tmp_path):
+    df = pd.DataFrame({'path': ['bad.jpg'], 'identity': ['a']})
+    bad_file = tmp_path / 'bad.jpg'
+    bad_file.touch()  # create empty file
+    dataset = ImageDataset(df, root=tmp_path)
+    with pytest.raises(ValueError):
+        dataset[0]

--- a/wildlife_tools/data/dataset.py
+++ b/wildlife_tools/data/dataset.py
@@ -58,10 +58,39 @@ class ImageDataset:
         return len(self.metadata)
 
     def get_image(self, path):
+        """Load an image from the filesystem.
+
+        Parameters
+        ----------
+        path : str
+            Path to image file.
+
+        Returns
+        -------
+        PIL.Image.Image
+            Loaded image converted to RGB.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the file does not exists.
+        ValueError
+            If the image cannot be read or is empty/corrupt.
+        """
+
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"Image file not found: {path}")
+
         img = cv2.imread(path)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-        img = Image.fromarray(img)
-        return img
+        if img is None or img.size == 0:
+            raise ValueError(f"Unable to load image or image is empty: {path}")
+
+        try:
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        except cv2.error as e:
+            raise ValueError(f"Failed to convert image '{path}' to RGB") from e
+
+        return Image.fromarray(img)
 
     def __getitem__(self, idx):
         data = self.metadata.iloc[idx]


### PR DESCRIPTION
## Summary
- make `ImageDataset` robust to corrupt or missing files
- document this change in README and docs
- test failure cases for missing or corrupt image paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torchvision')*

------
https://chatgpt.com/codex/tasks/task_b_68495104ffe88323b18023061deac882